### PR TITLE
Fix typo in googleVis.Rnw

### DIFF
--- a/vignettes/googleVis.Rnw
+++ b/vignettes/googleVis.Rnw
@@ -997,7 +997,7 @@ system.file("brew", package = "googleVis")
 \subsubsection{Using \googleVis with \Rook}
 
 \Rook~\cite{Rook} is a web server interface for R, written by Jeffrey Horner, the author 
-of rApache and brew. Compared to other web frameworks \Rook appears incredible lightweight.
+of rApache and brew. Compared to other web frameworks \Rook appears incredibly lightweight.
 \Rook doesn't need any configuration. It is an R package, which works out of the box with the R HTTP 
 server. That means no configuration files are needed. No files have to be placed 
 in particular folders. Instead, \Rook web applications can be run on a local desktop. 


### PR DESCRIPTION
Line 1000 --
Originally said: "Rook appears incredible lightweight."
Changed to: "Rook appears incredibly lightweight."