### PR TITLE
Allow custom HTML tooltips in gvisGeoCharts

### DIFF
--- a/R/gvis.R
+++ b/R/gvis.R
@@ -467,6 +467,11 @@ gvisCheckData <- function(data="", options=list(), data.structure=list()){
                                      names(options$data) != "allowed" &
                                      names(options$data) != "date.format"])]
   
+  html.tooltip.col <- names(data)[endsIn(names(data), '.tooltip')]
+  if (length(html.tooltip.col) == 1) {
+    x[[html.tooltip.col]] <- data[[html.tooltip.col]]
+  }
+  
   sapply(names(options$data[options$data!="" & names(options$data) !=
                               "allowed" & names(options$data) != "date.format"]), 
          function(.x){ 


### PR DESCRIPTION
We cannot currently override gvisGeoChart default tooltips with custom HTML ones. It works in the rest of the chart types thanks to the naming of the columns (as you know, the library assumes that a column named "whatever.tooltip" is a custom HTML tooltip). But it doesn't work with gvisGeoCharts, since that type of chart is currently discarding most of the columns of the data.frames passed as data to the function call. It keeps the specific columns it needs (colour to show, areas to paint, default tooltip headers, etc.), but it discards the rest. It makes no difference, then, trying to add a "whatever.tooltip" column to the data.frame, as it is automatically ignored.

Since a GeoChart can only have one single tooltip column, this change I propose works like this: 

As soon as the filtering of 'unknown' columns finishes for a gvisGeoChart, it looks if there is 1 and only 1 column in the original data named 'whatever.tooltip', and it restores it.

**It is a minor change and it gives full control over GeoChart tooltips.**